### PR TITLE
fix file url

### DIFF
--- a/src/main/java/com/tale/init/TaleLoader.java
+++ b/src/main/java/com/tale/init/TaleLoader.java
@@ -7,6 +7,8 @@ import com.tale.utils.ExtClasspathLoader;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -29,6 +31,11 @@ public final class TaleLoader {
     public static void loadThemes(){
         BConfig bConfig = $().bConfig();
         String themeDir = AttachController.CLASSPATH + "templates/themes";
+    	try {
+			themeDir = new URI(themeDir).getPath();
+		} catch (URISyntaxException e) {
+			e.printStackTrace();
+		}  
         File[] dir = new File(themeDir).listFiles();
         for(File f : dir){
             if(f.isDirectory() && FileKit.isDirectory(f.getPath() + "/static")){

--- a/src/main/java/com/tale/init/WebContext.java
+++ b/src/main/java/com/tale/init/WebContext.java
@@ -22,6 +22,8 @@ import jetbrick.template.resolver.GlobalResolver;
 
 import javax.servlet.ServletContext;
 import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * Tale初始化进程
@@ -41,6 +43,11 @@ public class WebContext implements BeanProcessor, WebContextListener {
         templateEngine.addConfig("jetx.import.macros", "/comm/macros.html");
         // 扫描主题下面的所有自定义宏
         String themeDir = AttachController.CLASSPATH + "templates/themes";
+    	try {
+			themeDir = new URI(themeDir).getPath();
+		} catch (URISyntaxException e) {
+			e.printStackTrace();
+		}  
         File[] dir = new File(themeDir).listFiles();
         for(File f : dir){
             if(f.isDirectory() && FileKit.exist(f.getPath() + "/macros.html")){


### PR DESCRIPTION
如果项目路径包含中文空格或其它特殊符号如“+”，将无法访问到文件。
在blade中也修改了一些，另外需升级jetbrick-commons到2.1.3。

![1](https://cloud.githubusercontent.com/assets/23714483/23497792/c1a1337c-ff5f-11e6-9114-d920d2ab5bb1.png)
