### PR TITLE
Renamed inconsistent identifiers

### DIFF
--- a/src/main/java/com/tale/controller/IndexController.java
+++ b/src/main/java/com/tale/controller/IndexController.java
@@ -65,8 +65,8 @@ public class IndexController extends BaseController {
      * 自定义页面
      */
     @Route(values = {"/:pagename", "/:pagename.html"}, method = HttpMethod.GET)
-    public String page(@PathParam String pagename, Request request) {
-        Contents contents = contentsService.getContents(pagename);
+    public String page(@PathParam String cid, Request request) {
+        Contents contents = contentsService.getContents(cid);
         if (null == contents) {
             return this.render_404();
         }
@@ -89,18 +89,18 @@ public class IndexController extends BaseController {
      * 首页分页
      *
      * @param request
-     * @param pageIndex
+     * @param page
      * @param limit
      * @return
      */
     @Route(values = {"page/:pageIndex", "page/:pageIndex.html"}, method = HttpMethod.GET)
-    public String index(Request request, @PathParam int pageIndex, @QueryParam(value = "limit", defaultValue = "12") int limit) {
-        pageIndex = pageIndex < 0 || pageIndex > TaleConst.MAX_PAGE ? 1 : pageIndex;
-        Take take = new Take(Contents.class).eq("type", Types.ARTICLE).eq("status", Types.PUBLISH).page(pageIndex, limit, "created desc");
+    public String index(Request request, @PathParam int page, @QueryParam(value = "limit", defaultValue = "12") int limit) {
+        page = page < 0 || page > TaleConst.MAX_PAGE ? 1 : page;
+        Take take = new Take(Contents.class).eq("type", Types.ARTICLE).eq("status", Types.PUBLISH).page(page, limit, "created desc");
         Paginator<Contents> articles = contentsService.getArticles(take);
         request.attribute("articles", articles);
-        if (pageIndex > 1) {
-            this.title(request, "第" + pageIndex + "页");
+        if (page > 1) {
+            this.title(request, "第" + page + "页");
         }
         request.attribute("is_home", true);
         request.attribute("page_prefix", "/page");

--- a/src/main/java/com/tale/controller/InstallController.java
+++ b/src/main/java/com/tale/controller/InstallController.java
@@ -76,12 +76,12 @@ public class InstallController extends BaseController {
                 return RestResponse.fail("邮箱格式不正确");
             }
 
-            Users users = new Users();
-            users.setUsername(admin_user);
-            users.setPassword(admin_pwd);
-            users.setEmail(admin_email);
+            Users temp = new Users();
+            temp.setUsername(admin_user);
+            temp.setPassword(admin_pwd);
+            temp.setEmail(admin_email);
 
-            siteService.initSite(users);
+            siteService.initSite(temp);
 
             if (site_url.endsWith("/")) {
                 site_url = site_url.substring(0, site_url.length() - 1);

--- a/src/main/java/com/tale/init/WebContext.java
+++ b/src/main/java/com/tale/init/WebContext.java
@@ -63,9 +63,9 @@ public class WebContext implements BeanProcessor, WebContextListener {
                 macros.add(macroName);
             }
         }
-        StringBuffer macroBuf = new StringBuffer();
-        macros.forEach(s -> macroBuf.append(',').append(s));
-        templateEngine.addConfig("jetx.import.macros", macroBuf.substring(1));
+        StringBuffer sbuf = new StringBuffer();
+        macros.forEach(s -> sbuf.append(',').append(s));
+        templateEngine.addConfig("jetx.import.macros", sbuf.substring(1));
 
         GlobalResolver resolver = templateEngine.getGlobalResolver();
         resolver.registerFunctions(Commons.class);

--- a/src/main/java/com/tale/utils/TaleUtils.java
+++ b/src/main/java/com/tale/utils/TaleUtils.java
@@ -338,9 +338,9 @@ public class TaleUtils {
         OutputStream out = response.outputStream();
         FileInputStream in = new FileInputStream(file);
         byte[] buffer = new byte[1024];
-        int length;
-        while ((length = in.read(buffer)) > 0) {
-            out.write(buffer, 0, length);
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
         }
         in.close();
         out.flush();


### PR DESCRIPTION
I used an automatic tool which suggests useful renaming operations based on the frequency such names appear in the code-base. For example, "page" appears more frequently than "pageIndex" in the context in which "pageIndex" is used, so I renamed it. I did not modify functional parts of the code, I just applied such renamings.