### PR TITLE
修复 修改attach_url后导致图片类型文件无法预览的问题

### DIFF
--- a/src/main/resources/templates/admin/attach.html
+++ b/src/main/resources/templates/admin/attach.html
@@ -69,7 +69,7 @@
         <div class="col-md-2 text-center m-t-10">
             <a href="${attach_url}${attach.fkey}" target="_blank">
                 <img class="attach-img"
-                     src="#if(attach.ftype == 'image') ${attach_url}${attach.fkey} #else /static/admin/images/attach.png #end"
+                     src="#if(attach.ftype == 'image') //${attach_url}${attach.fkey} #else /static/admin/images/attach.png #end"
                      title="${attach.fname}"/>
             </a>
             <div class="clearfix m-t-10">


### PR DESCRIPTION
修改attach_url后, ${attach_url}${attach.fkey}写法会出现  domin/admin/${attach_url}${attach.fkey}的情况导致无法预览图片.修改写法为
//${attach_url}${attach.fkey} 则不会出现domin/admin