### PR TITLE
添加截取文章摘要(返回HTML)方法

### DIFF
--- a/src/main/java/com/tale/extension/Theme.java
+++ b/src/main/java/com/tale/extension/Theme.java
@@ -284,6 +284,25 @@ public final class Theme {
     }
 
     /**
+     * 截取文章摘要(返回HTML)
+     *
+     * @param value 文章内容
+     * @return 转换 markdown 为 html
+     */
+    public static String intro(String value) {
+        if (StringKit.isBlank(value)) {
+            return null;
+        }
+        int pos = value.indexOf("<!--more-->");
+        if (pos != -1) {
+            String html = value.substring(0, pos);
+            return TaleUtils.mdToHtml(html);
+        } else {
+            return TaleUtils.mdToHtml(value);
+        }
+    }
+
+    /**
      * 截取文章摘要
      *
      * @param value 文章内容


### PR DESCRIPTION
现有的方法中，没有获取摘要并转化为HTML后返回的方法
当摘要部分有代码时，返回文本格式，代码部分排版会有问题
![image](https://user-images.githubusercontent.com/15064137/46591884-73e2b800-caf0-11e8-93fc-0fb637010186.png)
转换成HTML后:
![image](https://user-images.githubusercontent.com/15064137/46591899-91b01d00-caf0-11e8-82bf-2101f385aca2.png)
